### PR TITLE
Track upstream branches in .gitmodules (for nightly submodule auto-bump)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "analyzers/parse-en-us"]
 	path = analyzers/parse-en-us
 	url = https://github.com/VisualText/parse-en-us.git
+	branch = main
 [submodule "analyzer-templates"]
 	path = analyzer-templates
 	url = https://github.com/VisualText/analyzer-templates
+	branch = main


### PR DESCRIPTION
Adds `branch =` lines so `git submodule update --remote` follows the correct branch. Prerequisite for the nightly submodule auto-bump workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)