### PR TITLE
docs: add help pages for loadkbb and loaddict NLP++ functions

### DIFF
--- a/Help/markdown/Table_of_Knowledge_Base_Functions.md
+++ b/Help/markdown/Table_of_Knowledge_Base_Functions.md
@@ -14,6 +14,8 @@ In the table below, a **name** must be a STR, **parent** is a CON, **attr_str** 
 | --- | --- | --- |
 | **Command File Functions** |   |   |
 | [kbdumptree(root_con, file_str)](kbdumptree.md) | BOOL | Create a dump file of knowledge base concept. |
+| [loaddict(file_str)](loaddict.md) | BOOL | Load a `.dict` dictionary file from the `kb/user` directory into the conceptual grammar. |
+| [loadkbb(file_str)](loadkbb.md) | BOOL | Load a `.kbb` knowledge base file from the `kb/user` directory into the conceptual grammar. |
 | [**take(file_str)**](take.md) | BOOL | Execute commands in a knowledge base command file (.KB file) |
 | [writekb()](writekb.md) | BOOL | Dumps the entire KB currently in memory to the kb/user directory which includes a word.kb, attrs.kb, and main.kb file. |
 | **Functions that Find and Fetch** |   |   |

--- a/Help/markdown/index.md
+++ b/Help/markdown/index.md
@@ -270,6 +270,8 @@ to a topic.
           - [sorthier](sorthier.md)
         - **Command File**
           - [kbdumptree](kbdumptree.md)
+          - [loaddict](loaddict.md)
+          - [loadkbb](loadkbb.md)
           - [take](take.md)
         - **Dictionary**
           - [addword](addword.md)

--- a/Help/markdown/loaddict.md
+++ b/Help/markdown/loaddict.md
@@ -1,0 +1,52 @@
+[← Help Contents](index.md) | [📘 NLP++ Textbook](NLP++_Textbook.md)
+
+# loaddict
+
+## Purpose
+
+Load a single dictionary file (`.dict`) from the analyzer's `kb/user` directory into the conceptual grammar (the KB currently in memory).
+
+## Syntax
+
+## `returnedBoolean = loaddict(file_str)`
+
+```
+returnedBoolean - type: bool (1 or 0)
+```
+
+```
+file_str - type:  str
+```
+
+## Returns
+
+Returns **1** if the file was loaded successfully and **0** otherwise (for example, if the file is not found in `kb/user`).
+
+## Remarks
+
+`file_str` is the **name of a file in the analyzer's `kb/user` directory**, not a full path. The file is resolved as `<app>/kb/user/<file_str>`.
+
+A `.dict` file uses the flat `word attr=val ...` format, one word per line. `loaddict` adds those words and their attributes to the KB already in memory. If a `.kbb` file with the same stem exists in `kb/user`, its `dictionary` concept is used as the ambiguity KB for the words being added, mirroring how the engine pairs dictionaries with their KB during normal startup.
+
+To load an indented hierarchy file instead, use [loadkbb](loadkbb.md).
+
+## Example
+
+```
+@CODE
+```
+
+```
+if (loaddict("extra.dict"))
+    "loaded extra.dict" >> G("$apppath") + "\\load.log";
+```
+
+```
+@@CODE
+```
+
+This loads `<app>/kb/user/extra.dict` into the conceptual grammar.
+
+## See Also
+
+[loadkbb](loadkbb.md) &nbsp;|&nbsp; [take](take.md) &nbsp;|&nbsp; [writekb](writekb.md) &nbsp;|&nbsp; [dictfindword](dictfindword.md) &nbsp;|&nbsp; [Knowledge Base Functions](Table_of_Knowledge_Base_Functions.md)

--- a/Help/markdown/loadkbb.md
+++ b/Help/markdown/loadkbb.md
@@ -1,0 +1,52 @@
+[← Help Contents](index.md) | [📘 NLP++ Textbook](NLP++_Textbook.md)
+
+# loadkbb
+
+## Purpose
+
+Load a single knowledge base binary file (`.kbb`) from the analyzer's `kb/user` directory into the conceptual grammar (the KB currently in memory).
+
+## Syntax
+
+## `returnedBoolean = loadkbb(file_str)`
+
+```
+returnedBoolean - type: bool (1 or 0)
+```
+
+```
+file_str - type:  str
+```
+
+## Returns
+
+Returns **1** if the file was loaded successfully and **0** otherwise (for example, if the file is not found in `kb/user`).
+
+## Remarks
+
+`file_str` is the **name of a file in the analyzer's `kb/user` directory**, not a full path. The file is resolved as `<app>/kb/user/<file_str>`.
+
+A `.kbb` file uses the indented "dictionary" format, where indentation expresses the concept hierarchy. `loadkbb` adds the concepts in the file to the KB already in memory, hanging them off the existing hierarchy. This is the same mechanism the engine uses when it loads `*.kbb` files during normal KB startup, exposed so an analyzer can pull in an additional `.kbb` on demand.
+
+To load a flat `word attr=val ...` dictionary file instead, use [loaddict](loaddict.md).
+
+## Example
+
+```
+@CODE
+```
+
+```
+if (loadkbb("extra.kbb"))
+    "loaded extra.kbb" >> G("$apppath") + "\\load.log";
+```
+
+```
+@@CODE
+```
+
+This loads `<app>/kb/user/extra.kbb` into the conceptual grammar.
+
+## See Also
+
+[loaddict](loaddict.md) &nbsp;|&nbsp; [take](take.md) &nbsp;|&nbsp; [writekb](writekb.md) &nbsp;|&nbsp; [kbdumptree](kbdumptree.md) &nbsp;|&nbsp; [Knowledge Base Functions](Table_of_Knowledge_Base_Functions.md)


### PR DESCRIPTION
## Summary

Documents two new NLP++ built-in functions that load a file from the analyzer's `kb/user` directory into the conceptual grammar:

- **`loadkbb(file_str)`** — load an indented `*.kbb` hierarchy file
- **`loaddict(file_str)`** — load a flat `*.dict` dictionary file

## Changes

- New help pages `Help/markdown/loadkbb.md` and `Help/markdown/loaddict.md`, following the existing `take.md` / `writekb.md` page format (Purpose / Syntax / Returns / Remarks / Example / See Also).
- Wired both into `Help/markdown/index.md` (under **Command File**) and `Help/markdown/Table_of_Knowledge_Base_Functions.md`.

## Related

Engine implementation: VisualText/nlp-engine#652

🤖 Generated with [Claude Code](https://claude.com/claude-code)